### PR TITLE
Initial HatchMCP code as a standalone package

### DIFF
--- a/hatch_mcp_server/__init__.py
+++ b/hatch_mcp_server/__init__.py
@@ -1,0 +1,17 @@
+"""
+Hatch MCP Server - The wrapper for MCP servers to service Hatch-related applications.
+
+This package provides a class for extending MCP servers with additional functionalities
+relevant to the Hatch ecosystem. This includes:
+
+- Citations for Origin Software and MCP server implementations as MCP resources.
+
+"""
+
+__version__ = "0.1.0"
+
+from .hatch_mcp import HatchMCP
+
+__all__ = [
+    'HatchMCP'
+]

--- a/hatch_mcp_server/hatch_mcp.py
+++ b/hatch_mcp_server/hatch_mcp.py
@@ -1,0 +1,90 @@
+import os
+import inspect
+import logging
+from typing import Optional
+from mcp.server.fastmcp import FastMCP
+from hatchling.core.logging.logging_manager import logging_manager
+
+class HatchMCP():
+    """Base wrapper for MCP servers with citation capabilities."""
+    
+    def __init__(self, 
+                 name: str, 
+                 origin_citation: Optional[str] = None, 
+                 mcp_citation: Optional[str] = None):
+        """Initialize the HatchMCP wrapper.
+        
+        Args:
+            name (str): The name of the MCP server.
+            origin_citation (str, optional): Citation information for the original tools/algorithms. Defaults to None.
+            mcp_citation (str, optional): Citation information for the MCP server implementation. Defaults to None.
+        """
+        # Initialize the logger
+        self.logger = logging_manager.get_session(
+            f"HatchMCP_{name}",
+            formatter=logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        )
+
+        # Create the underlying FastMCP server
+        self.server = FastMCP(name, log_level="WARNING")
+        self.name = name
+        self.module_name = "" #the file name of the calling module
+        
+        # Store citation information
+        self._origin_citation = origin_citation or "No origin citation provided."
+        self._mcp_citation = mcp_citation or "No MCP citation provided."
+
+        # Determine the filename of the calling module for citation URIs
+        try:
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
+            if module and module.__file__:
+                self.module_name = module.__file__[1:]
+                self.logger.info(f"Module name for citation URIs: {self.module_name}")
+        except Exception:
+            raise RuntimeError("Unable to determine module name for citation URIs.")
+        
+        # Register a resource to discover the server name
+        # This allows clients to query server_name://hatch to get the correct name for citation URIs
+        @self.server.resource(
+            uri=f"name://{self.module_name}",
+            name="Server Name",
+            description="The name of this MCP server for use in other resource URIs",
+            mime_type="text/plain"
+        )
+        def get_server_name() -> str:
+            """Return the name of this MCP server.
+            
+            Returns:
+                str: The name of the MCP server.
+            """
+            return self.name
+
+        # Register citation resources using standard URIs and the resource decorator
+        @self.server.resource(
+            uri=f"citation://origin/{name}",
+            name="Origin Citation",
+            description="Citation information for the original tools/algorithms",
+            mime_type="text/plain"
+        )
+        def get_origin_citation() -> str:
+            """Return citation information for the wrapped tools.
+            
+            Returns:
+                str: Citation information text.
+            """
+            return self._origin_citation
+        
+        @self.server.resource(
+            uri=f"citation://mcp/{name}",
+            name="MCP Implementation Citation",
+            description="Citation information for the MCP server implementation",
+            mime_type="text/plain"
+        )
+        def get_mcp_citation() -> str:
+            """Return citation information for the MCP server developers.
+            
+            Returns:
+                str: Citation information text.
+            """
+            return self._mcp_citation

--- a/hatch_mcp_server/hatch_mcp.py
+++ b/hatch_mcp_server/hatch_mcp.py
@@ -3,7 +3,6 @@ import inspect
 import logging
 from typing import Optional
 from mcp.server.fastmcp import FastMCP
-from hatchling.core.logging.logging_manager import logging_manager
 
 class HatchMCP():
     """Base wrapper for MCP servers with citation capabilities."""
@@ -20,10 +19,7 @@ class HatchMCP():
             mcp_citation (str, optional): Citation information for the MCP server implementation. Defaults to None.
         """
         # Initialize the logger
-        self.logger = logging_manager.get_session(
-            f"HatchMCP_{name}",
-            formatter=logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        )
+        self.logger = logging.getLogger("hatch_mcp_server.HatchMCP")
 
         # Create the underlying FastMCP server
         self.server = FastMCP(name, log_level="WARNING")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hatch-mcp-server"
+version = "0.1.0"
+authors = [
+  { name = "Hatch Team" },
+]
+description = "Wrapper for MCP servers to service Hatch-related apps."
+readme = "README.md"
+requires-python = ">=3.12"
+classifiers = [
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "Operating System :: OS Independent",
+]
+
+dependencies = [
+    "mcp>=1.6.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/CrackingShells/Hatch-MCP-Server"
+"Bug Tracker" = "https://github.com/CrackingShells/Hatch-MCP-Server/issues"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
This pull request introduces the initial implementation of the `Hatch MCP Server`, a wrapper for MCP servers designed to support Hatch-related applications. The key changes include the creation of the `HatchMCP` class with citation capabilities, the addition of project metadata in `pyproject.toml`, and the initialization of the package structure.

### New `Hatch MCP Server` Implementation:

* **`hatch_mcp_server/hatch_mcp.py`**: Introduced the `HatchMCP` class, which wraps MCP servers and provides citation capabilities. This includes:
  - Initializing a `FastMCP` server with a specified name.
  - Storing and exposing citation information for origin tools and MCP implementations via URI-based resources.
  - Dynamically determining the module name for citation URIs.

* **`hatch_mcp_server/__init__.py`**: Added the package's initialization file, which defines the module's version and exposes the `HatchMCP` class.

### Project Metadata:

* **`pyproject.toml`**: Added metadata and configuration for the project, including:
  - Project name, version, authors, and description.
  - Dependencies (`mcp>=1.6.0`) and Python version requirement (`>=3.12`).
  - Build system configuration using `setuptools`.