### PR TITLE
Decoupling Hatch MCP from Fast MCP

### DIFF
--- a/hatch_mcp_server/__init__.py
+++ b/hatch_mcp_server/__init__.py
@@ -8,7 +8,7 @@ relevant to the Hatch ecosystem. This includes:
 
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .hatch_mcp import HatchMCP
 

--- a/hatch_mcp_server/hatch_mcp.py
+++ b/hatch_mcp_server/hatch_mcp.py
@@ -8,7 +8,8 @@ class HatchMCP():
     """Base wrapper for MCP servers with citation capabilities."""
     
     def __init__(self, 
-                 name: str, 
+                 name: str,
+                 fast_mcp: Optional[FastMCP] = None,
                  origin_citation: Optional[str] = None, 
                  mcp_citation: Optional[str] = None):
         """Initialize the HatchMCP wrapper.
@@ -22,7 +23,7 @@ class HatchMCP():
         self.logger = logging.getLogger("hatch_mcp_server.HatchMCP")
 
         # Create the underlying FastMCP server
-        self.server = FastMCP(name, log_level="WARNING")
+        self.server = fast_mcp or FastMCP(name, log_level="WARNING")
         self.name = name
         self.module_name = "" #the file name of the calling module
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name = "Hatch Team" },
 ]


### PR DESCRIPTION
Introduces support for injecting a custom `FastMCP` instance into the `HatchMCP` class


### New Feature: Custom `FastMCP` Injection:
* Added an optional `fast_mcp` parameter to the `HatchMCP` class constructor, allowing users to inject a custom `FastMCP` instance. (`hatch_mcp_server/hatch_mcp.py`)
* Updated the `HatchMCP` initialization logic to use the provided `fast_mcp` instance if available, or create a default `FastMCP` instance otherwise. (`hatch_mcp_server/hatch_mcp.py`)

Resolves #1 